### PR TITLE
Fix #77: Apache 2.0 license clause in source codes

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 import org.gradle.api.JavaVersion

--- a/buildSrc/src/main/kotlin/ProjectConfiguration.kt
+++ b/buildSrc/src/main/kotlin/ProjectConfiguration.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 import com.android.build.api.dsl.BaseFlavor

--- a/library/src/androidTest/AndroidManifest.xml
+++ b/library/src/androidTest/AndroidManifest.xml
@@ -1,12 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2022 Wultra s.r.o.
   ~
-  ~ All rights reserved. This source code can be used only for purposes specified
-  ~ by the given license contract signed by the rightful deputy of Wultra s.r.o.
-  ~ This source code can be used only by the owner of the license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Any disputes arising in respect of this agreement (license) shall be brought
-  ~ before the Municipal Court of Prague.
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions
+  ~ and limitations under the License.
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"

--- a/library/src/androidTest/java/IntegrationTests.kt
+++ b/library/src/androidTest/java/IntegrationTests.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.test

--- a/library/src/androidTest/java/IntegrationUtils.kt
+++ b/library/src/androidTest/java/IntegrationUtils.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.test

--- a/library/src/androidTest/java/OperationExpirationTests.kt
+++ b/library/src/androidTest/java/OperationExpirationTests.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.test

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/Compatibility.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/Compatibility.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 @file:Suppress("unused")

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/general/Compatibility.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/general/Compatibility.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.general

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/AttributeTypeAdapter.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/AttributeTypeAdapter.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/OperationApi.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/OperationApi.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/OperationHistoryEntryDeserializer.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/OperationHistoryEntryDeserializer.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/ZonedDateTimeDeserializer.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/ZonedDateTimeDeserializer.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/AuthorizeRequestObject.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/AuthorizeRequestObject.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/IOperation.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/IOperation.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/LocalOperation.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/LocalOperation.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/OperationAttribute.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/OperationAttribute.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/QROperation.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/QROperation.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/QROperationParser .kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/QROperationParser .kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/RejectRequest.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/RejectRequest.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/UserOperation.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/model/UserOperation.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/push/PushApi.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/push/PushApi.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.push

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/push/model/PushRegistrationRequestObject.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/push/model/PushRegistrationRequestObject.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.push.model

--- a/library/src/main/java/com/wultra/android/mtokensdk/common/Logger.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/common/Logger.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.common

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/IOperationsService.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/IOperationsService.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/IOperationsServiceListener.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/IOperationsServiceListener.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/OperationResultListeners.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/OperationResultListeners.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/OperationsService.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/OperationsService.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/OperationsUtils.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/OperationsUtils.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/RejectionReason.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/RejectionReason.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.operation

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/expiration/CurrentDateProvider.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/expiration/CurrentDateProvider.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.operation.expiration

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/expiration/ExpirableOperation.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/expiration/ExpirableOperation.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.operation.expiration

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/expiration/OperationExpirationWatcher.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/expiration/OperationExpirationWatcher.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 @file:Suppress("unused")

--- a/library/src/main/java/com/wultra/android/mtokensdk/push/IPushService.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/push/IPushService.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.push

--- a/library/src/main/java/com/wultra/android/mtokensdk/push/PushParser.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/push/PushParser.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.push

--- a/library/src/main/java/com/wultra/android/mtokensdk/push/PushService.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/push/PushService.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.push

--- a/library/src/test/java/OperationJsonDeserializationTests.kt
+++ b/library/src/test/java/OperationJsonDeserializationTests.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation

--- a/library/src/test/java/PushTests.kt
+++ b/library/src/test/java/PushTests.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation

--- a/library/src/test/java/QRParserTests.kt
+++ b/library/src/test/java/QRParserTests.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.mtokensdk.api.operation


### PR DESCRIPTION
This PR fixes Apache 2.0 license clause in source codes.