### PR TITLE
Update documentation for release 1.5.x

### DIFF
--- a/docs/Migration-1.5.md
+++ b/docs/Migration-1.5.md
@@ -1,0 +1,36 @@
+# Migration from 1.4.x to 1.5.x
+
+This guide contains instructions for migration from Wultra Mobile Token SDK for Android version `1.4.x` to version `1.5.x`.
+
+## Deprecated APIs
+
+All API calls based on listener interfaces are now deprecated and you can now use the new callbacks returning `Result<T>` as a replacement.
+
+Deprecated functions in `IOperationsService`:
+
+- `fun getLastOperationsResult(): OperationsResult?`
+  - Replace with `lastOperationsResult` property.
+- `fun getOperations(listener: IGetOperationListener?)`
+  - Replace with `fun getOperations(callback: (result: Result<List<UserOperation>>) -> Unit)`
+- `fun getHistory(authentication: PowerAuthAuthentication, listener: IGetHistoryListener)`
+  - Replace with `fun getHistory(authentication: PowerAuthAuthentication, callback: (result: Result<List<OperationHistoryEntry>>) -> Unit)`
+- `fun authorizeOperation(operation: IOperation, authentication: PowerAuthAuthentication, listener: IAcceptOperationListener)`
+  - Replace with `fun authorizeOperation(operation: IOperation, authentication: PowerAuthAuthentication, callback: (result: Result<Unit>) -> Unit)`
+- `fun rejectOperation(operation: IOperation, reason: RejectionReason, listener: IRejectOperationListener)`
+  - Replace with `fun rejectOperation(operation: IOperation, reason: RejectionReason, callback: (result: Result<Unit>) -> Unit)`
+
+Deprecated functions in `IPushService`:
+
+- `fun register(fcmToken: String, listener: IPushRegisterListener)`
+  - Replace with `fun register(fcmToken: String, callback: (result: Result<Unit>) -> Unit)`
+  
+Deprecated interfaces and classes:
+
+- `interface IAcceptOperationListener`
+- `interface IRejectOperationListener`
+- `interface IGetOperationListener`
+- `interface IGetHistoryListener`
+- `interface IPushRegisterListener`
+- `abstract class OperationsResult`
+- `data class SuccessOperationsResult`
+- `data class ErrorOperationsResult`

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,13 @@ Remarks:
 - This library does not contain any UI.
 - We also provide an [iOS version of this library](https://github.com/wultra/mtoken-sdk-ios). 
 
+## Migration Guides
+
+If you need to upgrade Wultra Mobile Token SDK for Android to a newer version, you can check the following migration guides:
+
+- [Migration from version `1.4.x` to `1.5.x`](Migration-1.5.md)
+
+
 <!-- begin remove -->
 ## Integration Tutorials
 - [SDK Integration](SDK-Integration.md)

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -24,4 +24,7 @@ implementation "com.wultra.android.powerauth:powerauth-sdk:1.x.y"
 | WMT SDK | PowerAuth SDK |  
 |---|---|
 | `1.0.x` - `1.2.x` | `1.0.x` - `1.5.x` |
-| `1.3.x` | `1.6.x` |
+| `1.3.x` - `1.4.x` | `1.6.x` |
+| `1.5.x` | `1.7.x` |
+
+

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/Deprecated.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/Deprecated.kt
@@ -21,7 +21,7 @@ package com.wultra.android.mtokensdk.api
 import com.wultra.android.powerauth.networking.error.ApiErrorCode
 import com.wultra.android.powerauth.networking.error.ApiHttpException
 
-// Type aliases to for easier migration
+// Type aliases to for easier migration, Deprecated in 1.4.0
 
 @Deprecated(
     "This enum was moved and renamed.",

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/general/Compatibility.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/general/Compatibility.kt
@@ -18,7 +18,7 @@ package com.wultra.android.mtokensdk.api.general
 
 import com.wultra.android.powerauth.networking.error.ApiError
 
-// Type aliases to for easier migration
+// Type aliases to for easier migration, deprecated in 1.4.0
 
 @Deprecated(
     "This class was moved to different package (com.wultra.android.powerauth.networking.error).",

--- a/library/src/main/java/com/wultra/android/mtokensdk/operation/Deprecated.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/operation/Deprecated.kt
@@ -25,25 +25,25 @@ import com.wultra.android.mtokensdk.api.operation.model.UserOperation
 import com.wultra.android.powerauth.networking.error.ApiError
 import io.getlime.security.powerauth.sdk.PowerAuthAuthentication
 
-@Deprecated("Use API function with Result<Unit> callback.")
+@Deprecated("Use API function with Result<Unit> callback.") // 1.5.0
 interface IAcceptOperationListener {
     fun onSuccess()
     fun onError(error: ApiError)
 }
 
-@Deprecated("Use API function with Result<Unit> callback.")
+@Deprecated("Use API function with Result<Unit> callback.") // 1.5.0
 interface IRejectOperationListener {
     fun onSuccess()
     fun onError(error: ApiError)
 }
 
-@Deprecated("Use API function with Result<List<UserOperation>> callback.")
+@Deprecated("Use API function with Result<List<UserOperation>> callback.") // 1.5.0
 interface IGetOperationListener {
     fun onSuccess(operations: List<UserOperation>)
     fun onError(error: ApiError)
 }
 
-@Deprecated("Use API function with Result<List<OperationHistoryEntry>> callback.")
+@Deprecated("Use API function with Result<List<OperationHistoryEntry>> callback.") // 1.5.0
 interface IGetHistoryListener {
     fun onSuccess(operations: List<OperationHistoryEntry>)
     fun onError(error: ApiError)
@@ -51,11 +51,11 @@ interface IGetHistoryListener {
 
 // Deprecated interfaces and functions
 
-@Deprecated("Use Result<List<UserOperation>> based API")
+@Deprecated("Use Result<List<UserOperation>> based API") // 1.5.0
 abstract class OperationsResult
-@Deprecated("Use Result<List<UserOperation>> based API")
+@Deprecated("Use Result<List<UserOperation>> based API") // 1.5.0
 data class SuccessOperationsResult(val operations: List<UserOperation>): OperationsResult()
-@Deprecated("Use Result<List<UserOperation>> based API")
+@Deprecated("Use Result<List<UserOperation>> based API") // 1.5.0
 data class ErrorOperationsResult(val error: ApiError): OperationsResult()
 
 /**
@@ -63,7 +63,7 @@ data class ErrorOperationsResult(val error: ApiError): OperationsResult()
  *
  * @return Last getOperations result. Null if not performed yet.
  */
-@Deprecated("Use lastOperationsResult property", ReplaceWith("lastOperationsResult"))
+@Deprecated("Use lastOperationsResult property", ReplaceWith("lastOperationsResult")) // 1.5.0
 fun IOperationsService.getLastOperationsResult(): OperationsResult? {
     return lastOperationsResult?.let { result ->
         result.fold(
@@ -77,7 +77,7 @@ fun IOperationsService.getLastOperationsResult(): OperationsResult? {
  * Retrieves user operations and calls the listener when finished.
  * @param listener Operation result listener
  */
-@Deprecated("Use function with Result<List<UserOperation>> callback as a replacement")
+@Deprecated("Use function with Result<List<UserOperation>> callback as a replacement") // 1.5.0
 fun IOperationsService.getOperations(listener: IGetOperationListener?) {
     getOperations { result ->
         result.onSuccess {
@@ -94,7 +94,7 @@ fun IOperationsService.getOperations(listener: IGetOperationListener?) {
  * @param authentication PowerAuth authentication object
  * @param listener Result listener
  */
-@Deprecated("Use function with Result<List<OperationHistoryEntry>> callback as a replacement")
+@Deprecated("Use function with Result<List<OperationHistoryEntry>> callback as a replacement") // 1.5.0
 fun IOperationsService.getHistory(authentication: PowerAuthAuthentication, listener: IGetHistoryListener) {
     getHistory(authentication) { result ->
         result.onSuccess {
@@ -112,7 +112,7 @@ fun IOperationsService.getHistory(authentication: PowerAuthAuthentication, liste
  * @param authentication PowerAuth authentication object
  * @param listener Result listener
  */
-@Deprecated("Use function with Result<Unit> callback as a replacement")
+@Deprecated("Use function with Result<Unit> callback as a replacement") // 1.5.0
 fun IOperationsService.authorizeOperation(operation: IOperation, authentication: PowerAuthAuthentication, listener: IAcceptOperationListener) {
     authorizeOperation(operation, authentication) { result ->
         result.onSuccess {
@@ -130,7 +130,7 @@ fun IOperationsService.authorizeOperation(operation: IOperation, authentication:
  * @param reason Rejection reason
  * @param listener Result listener
  */
-@Deprecated("Use function with Result<Unit> callback as a replacement")
+@Deprecated("Use function with Result<Unit> callback as a replacement") // 1.5.0
 fun IOperationsService.rejectOperation(operation: IOperation, reason: RejectionReason, listener: IRejectOperationListener) {
     rejectOperation(operation, reason) { result ->
         result.onSuccess {

--- a/library/src/main/java/com/wultra/android/mtokensdk/push/Deprecated.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/push/Deprecated.kt
@@ -26,7 +26,7 @@ import com.wultra.android.powerauth.networking.error.ApiError
 /**
  * Listener for [IPushService.register] method.
  */
-@Deprecated("Use function with Result<Unit> callback as a replacement")
+@Deprecated("Use function with Result<Unit> callback as a replacement") // 1.5.0
 interface IPushRegisterListener {
     /**
      * Called when FCM token was registered on backend.
@@ -44,7 +44,7 @@ interface IPushRegisterListener {
  * @param fcmToken Firebase Cloud Messaging Token
  * @param listener Result listener
  */
-@Deprecated("Use function with Result<Unit> callback as a replacement")
+@Deprecated("Use function with Result<Unit> callback as a replacement") // 1.5.0
 fun IPushService.register(fcmToken: String, listener: IPushRegisterListener) {
     register(fcmToken) { result ->
         result.onSuccess {


### PR DESCRIPTION
This PR adds Migration guide to release 1.5 and marks all `@Deprecated` annotations with comment about the version the deprecation was introduced. This will help us to remove deprecated interfaces in the future.