### PR TITLE
Fix typos in docs in deeplink URI scheme

### DIFF
--- a/docs/Using-Operations-Service.md
+++ b/docs/Using-Operations-Service.md
@@ -629,7 +629,7 @@ data class PACData(
 ```
 
 - two methods are provided:
-  - `parseDeeplink(uri: Uri): PACData?` - URI is expected to be in the format `"scheme://code=$JWT"` or `scheme://operation?oid=5b753d0d-d59a-49b7-bec4-eae258566dbb&potp=12345678}`
+  - `parseDeeplink(uri: Uri): PACData?` - URI is expected to be in the format `scheme://code=$JWT` or `scheme://operation?oid=5b753d0d-d59a-49b7-bec4-eae258566dbb&potp=12345678`
   - `parseQRCode(code: String): PACData?` - code is to be expected in the same format as deeplink formats or as a plain JWT
   - mentioned JWT should be in the format `{“typ”:”JWT”, “alg”:”none”}.{“oid”:”5b753d0d-d59a-49b7-bec4-eae258566dbb”, “potp”:”12345678”} `
 


### PR DESCRIPTION
Fixes: #145 