### PR TITLE
Fixed R8 missing classes

### DIFF
--- a/library/consumer-proguard-rules.pro
+++ b/library/consumer-proguard-rules.pro
@@ -5,4 +5,4 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
--keepclassmembers enum com.wultra.android.mtokensdk.api.*.** { *; }
+-keep, allowobfuscation class com.wultra.android.mtokensdk.api.** { *; }

--- a/library/consumer-proguard-rules.pro
+++ b/library/consumer-proguard-rules.pro
@@ -5,4 +5,9 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
--keep, allowobfuscation class com.wultra.android.mtokensdk.api.** { *; }
+# handle Gson
+-keepclassmembers class com.wultra.android.mtokensdk.api.** {
+     <fields>;
+}
+# handle R8 full mode optimizations
+-keep, allowobfuscation class com.wultra.android.mtokensdk.api.**

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/inbox/model/GetList.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/inbox/model/GetList.kt
@@ -16,6 +16,8 @@
 
 package com.wultra.android.mtokensdk.api.inbox.model
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Request payload describing which page in messages list should be received.
  */
@@ -23,13 +25,16 @@ data class GetList(
     /**
      * Page number.
      */
+    @SerializedName("page")
     val page: Int,
     /**
      * Page size.
      */
+    @SerializedName("size")
     val size: Int,
     /**
      * Specify whether only unread messages should be received.
      */
+    @SerializedName("onlyUnread")
     val onlyUnread: Boolean
 )

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/inbox/model/GetMessageDetail.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/inbox/model/GetMessageDetail.kt
@@ -16,6 +16,8 @@
 
 package com.wultra.android.mtokensdk.api.inbox.model
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Request payload describing which message detail should be received.
  */
@@ -23,5 +25,6 @@ data class GetMessageDetail(
     /**
      * Message's identifier.
      */
+    @SerializedName("id")
     val id: String
 )

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/inbox/model/SetMessageRead.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/inbox/model/SetMessageRead.kt
@@ -16,6 +16,8 @@
 
 package com.wultra.android.mtokensdk.api.inbox.model
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Request payload describing which message should be set as read.
  */
@@ -23,5 +25,6 @@ data class SetMessageRead(
     /**
      * Message's identifier.
      */
+    @SerializedName("id")
     val id: String
 )

--- a/library/src/main/java/com/wultra/android/mtokensdk/inbox/InboxCount.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/inbox/InboxCount.kt
@@ -16,6 +16,8 @@
 
 package com.wultra.android.mtokensdk.inbox
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Object contains information about unread messages in inbox.
  */
@@ -23,5 +25,6 @@ data class InboxCount(
     /**
      * Number of unread messages in inbox.
      */
+    @SerializedName("countUnread")
     val countUnread: Int
 )

--- a/library/src/main/java/com/wultra/android/mtokensdk/inbox/InboxMessage.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/inbox/InboxMessage.kt
@@ -16,6 +16,7 @@
 
 package com.wultra.android.mtokensdk.inbox
 
+import com.google.gson.annotations.SerializedName
 import java.util.Date
 
 /**
@@ -25,26 +26,32 @@ data class InboxMessage(
     /**
      * Message's identifier.
      */
+    @SerializedName("id")
     val id: String,
     /**
      * Message's subject.
      */
+    @SerializedName("subject")
     val subject: String,
     /**
      * Message's summary. It typically contains a reduced information from message's body,
      * with no additional formatting.
      */
+    @SerializedName("summary")
     val summary: String,
     /**
      * Message body's content type.
      */
+    @SerializedName("type")
     val type: InboxContentType,
     /**
      * If `true`, then user already read the message.
      */
+    @SerializedName("read")
     val read: Boolean,
     /**
      * Date and time when the message was created.
      */
+    @SerializedName("timestampCreated")
     val timestampCreated: Date
 )

--- a/library/src/main/java/com/wultra/android/mtokensdk/inbox/InboxMessageDetail.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/inbox/InboxMessageDetail.kt
@@ -16,6 +16,7 @@
 
 package com.wultra.android.mtokensdk.inbox
 
+import com.google.gson.annotations.SerializedName
 import java.util.Date
 
 /**
@@ -23,20 +24,27 @@ import java.util.Date
  */
 data class InboxMessageDetail(
     /** Message's identifier. */
+    @SerializedName("id")
     val id: String,
     /** Message's subject. */
+    @SerializedName("subject")
     val subject: String,
     /**
      * Message's summary. It typically contains a reduced information from message's body,
      * with no additional formatting.
      */
+    @SerializedName("summary")
     val summary: String,
     /** Message's body. */
+    @SerializedName("body")
     val body: String,
     /** Message body's content type. */
+    @SerializedName("type")
     val type: InboxContentType,
     /** If `true`, then user already read the message. */
+    @SerializedName("read")
     val read: Boolean,
     /** Date and time when the message was created. */
+    @SerializedName("timestampCreated")
     val timestampCreated: Date
 )


### PR DESCRIPTION
Fixes #178

-> For inbox model classes added `@SerializedName` so its rules is applied to these classes

-> the whole api package kept as internal classes in `*Api.kt` might get thrown away by R8