### PR TITLE
Throw exception on invalid attribute structure in AttributeTypeAdapter

### DIFF
--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/AttributeTypeAdapter.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/AttributeTypeAdapter.kt
@@ -77,7 +77,7 @@ internal class AttributeTypeAdapter : TypeAdapter<Attribute>() {
                                     reader.nextNull()
                                     null
                                 }
-                                else -> throw IllegalStateException("Unexpected token for attribute value: ${reader.peek()} at name: $name")
+                                else -> throw IllegalStateException("Unexpected token for attribute value: $token at name: $name")
                             }
                         }
                     }

--- a/library/src/main/java/com/wultra/android/mtokensdk/api/operation/AttributeTypeAdapter.kt
+++ b/library/src/main/java/com/wultra/android/mtokensdk/api/operation/AttributeTypeAdapter.kt
@@ -41,45 +41,50 @@ internal class AttributeTypeAdapter : TypeAdapter<Attribute>() {
         var inPartyInfo = false
         val partyInfoMap = mutableMapOf<String, String>()
 
-        do {
+        loop@ while (true) {
             token = reader.peek()
-            if (token == JsonToken.NULL) {
-                reader.nextNull()
-                return null
-            }
-            if (token == JsonToken.BEGIN_OBJECT) {
-                if (attrMap["type"] == "PARTY_INFO") {
-                    inPartyInfo = true
+            when (token) {
+                JsonToken.NULL -> {
+                    reader.nextNull()
+                    return null
                 }
-                reader.beginObject()
-            }
-            if (token == JsonToken.END_OBJECT) {
-                if (inPartyInfo) {
-                    inPartyInfo = false
-                    reader.endObject()
-                } else {
-                    reader.endObject()
-                    break
+                JsonToken.BEGIN_OBJECT -> {
+                    if (attrMap["type"] == "PARTY_INFO") {
+                        inPartyInfo = true
+                    }
+                    reader.beginObject()
                 }
-            }
-            if (token == JsonToken.NAME) {
-                val name = reader.nextName()
-                if (inPartyInfo) {
-                    partyInfoMap[name] = reader.nextString()
-                } else {
-                    if (name != "partyInfo") {
-                        attrMap[name] = when (reader.peek()) {
-                            JsonToken.STRING -> reader.nextString()
-                            JsonToken.NUMBER -> BigDecimal(reader.nextDouble())
-                            JsonToken.BOOLEAN -> reader.nextBoolean()
-                            JsonToken.NULL -> null
-                            else -> null
+                JsonToken.END_OBJECT -> {
+                    if (inPartyInfo) {
+                        inPartyInfo = false
+                        reader.endObject()
+                    } else {
+                        reader.endObject()
+                        break@loop
+                    }
+                }
+                JsonToken.NAME -> {
+                    val name = reader.nextName()
+                    if (inPartyInfo) {
+                        partyInfoMap[name] = reader.nextString()
+                    } else {
+                        if (name != "partyInfo") {
+                            attrMap[name] = when (reader.peek()) {
+                                JsonToken.STRING -> reader.nextString()
+                                JsonToken.NUMBER -> BigDecimal(reader.nextDouble())
+                                JsonToken.BOOLEAN -> reader.nextBoolean()
+                                JsonToken.NULL -> {
+                                    reader.nextNull()
+                                    null
+                                }
+                                else -> throw IllegalStateException("Unexpected token for attribute value: ${reader.peek()} at name: $name")
+                            }
                         }
                     }
                 }
+                else -> throw IllegalStateException("Unexpected token: $token at path: ${reader.path}")
             }
-        } while (true)
-
+        }
         val type = try { Attribute.Type.valueOf(attrMap["type"] as? String ?: "UNKNOWN") } catch (e: Throwable) { Attribute.Type.UNKNOWN }
         val id: String = attrMap["id"] as? String ?: return null
         val label: String = attrMap["label"] as? String ?: return null

--- a/library/src/test/java/JsonDeserializationTests.kt
+++ b/library/src/test/java/JsonDeserializationTests.kt
@@ -19,7 +19,16 @@ package com.wultra.android.mtokensdk.api.operation
 import com.google.gson.Gson
 import com.google.gson.TypeAdapter
 import com.google.gson.reflect.TypeToken
-import com.wultra.android.mtokensdk.api.operation.model.*
+import com.wultra.android.mtokensdk.api.operation.model.AlertAttribute
+import com.wultra.android.mtokensdk.api.operation.model.AlertType
+import com.wultra.android.mtokensdk.api.operation.model.AmountAttribute
+import com.wultra.android.mtokensdk.api.operation.model.Attribute
+import com.wultra.android.mtokensdk.api.operation.model.ConversionAttribute
+import com.wultra.android.mtokensdk.api.operation.model.ImageAttribute
+import com.wultra.android.mtokensdk.api.operation.model.KeyValueAttribute
+import com.wultra.android.mtokensdk.api.operation.model.NoteAttribute
+import com.wultra.android.mtokensdk.api.operation.model.PartyInfoAttribute
+import com.wultra.android.mtokensdk.api.operation.model.UserOperationStatus
 import com.wultra.android.mtokensdk.api.push.PushRegistrationRequest
 import com.wultra.android.mtokensdk.api.push.model.PushRegistrationRequestObject
 import com.wultra.android.mtokensdk.operation.OperationsUtils
@@ -520,5 +529,52 @@ class JsonDeserializationTests {
         val operation = typeAdapter.fromJson(json).responseObject[0]
         Assert.assertNotNull("Failed to parse JSON data", operation)
         Assert.assertEquals(UserOperationStatus.PENDING, operation.status)
+    }
+
+    @Test
+    fun `test attribute deserialization throws on invalid structure`() {
+        // Invalid: attribute params structure - array instead of an object
+        val json = """
+        {
+            "status": "OK",
+            "responseObject": [
+                {
+                    "id": "test-id",
+                    "name": "test",
+                    "data": "A1",
+                    "operationCreated": "2025-07-29T14:43:33+0000",
+                    "operationExpires": "2025-07-29T14:48:33+0000",
+                    "allowedSignatureType": {
+                        "type": "2FA",
+                        "variants": ["possession_knowledge"]
+                    },
+                    "formData": {
+                        "title": "Test",
+                        "message": "Test",
+                        "attributes": [
+                              {
+                                    "id": "operation.info",
+                                    "type": "INFO",
+                                    "params": [
+                                          {
+                                            "type": "info",
+                                            "message": "OK"
+                                          }
+                                    ]
+                              }
+                        ]
+                    }
+                }
+            ]
+        }
+        """.trimIndent()
+
+        var thrown: Throwable? = null
+        try {
+            typeAdapter.fromJson(json)
+        } catch (t: Throwable) {
+            thrown = t
+        }
+        Assert.assertNotNull("Expected exception for invalid attribute structure", thrown)
     }
 }


### PR DESCRIPTION
Fixes #217

- If an unsupported JSONToken is in the Attributes payload, we throw an error instead of the current infinite loop.